### PR TITLE
Change MIT Licence copyright year

### DIFF
--- a/legal.html
+++ b/legal.html
@@ -46,7 +46,7 @@
     <h1 class="title">License</h1>
     <p class="body">MIT License<br>
 
-Copyright (c) 2022 Meower Media.<br><br><br>
+Copyright (c) 2023 Meower Media.<br><br><br>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -110,8 +110,10 @@ SOFTWARE.</p>
       <br>b. Your profile description and profile icon.
       <br>c. Posts, comments, messages, and/or threads you create/reply to.
       <br>d. Basic diagnostic data (Timestamps of logins/logouts, timestamps of failed login attempts, timestamps of moderated posts/comments/messages/threads).
-      <!-- Doesn't exist yet <br>e. People you friend.
-      <br>f. Reputation data (“+Meows”, “-Meows”)!-->
+      <!-- Doesn't exist yet
+      <br>e. People you friend.
+      <br>f. Reputation data (“+Meows”, “-Meows”)
+      -->
       <br>e. Your current state of authentication (to verify account activity and determine if an account has gone inactive).</p>
       <br>
       <p class="body"><b>You have the right to view, manage, and/or delete your account, diagnostics data, or content you've shared on Meower.</b>

--- a/legal.html
+++ b/legal.html
@@ -46,7 +46,7 @@
     <h1 class="title">License</h1>
     <p class="body">MIT License<br>
 
-Copyright (c) 2023 Meower Media.<br><br><br>
+Copyright (c) <script type="text/javascript">document.write( new Date().getFullYear() );</script> Meower Media.<br><br><br>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR fixes the MIT Licence copyright year to 2023 in the Legal page. For some reason, nobody noticed that.